### PR TITLE
Fix login link

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -5,7 +5,7 @@
   <title>Dolphin Audio</title>
 </head>
 <body>
-  <a href="{{ url_for('login') }}">
+  <a href="/login">
     <button style="padding: 1em 2em; font-size: 1.2em; background-color: #1DB954; color: white; border: none; border-radius: 5px;">
       Log in with Spotify 🎵
     </button>


### PR DESCRIPTION
## Summary
- use `/login` route link in the index page instead of the previous Spotify URL

## Testing
- `pytest -q`
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68824f1657c483328fa6cab6effa7921