### PR TITLE
Improve Spotify OAuth setup guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,31 @@
+# Dolphin Spotify Genome App
+
+This Flask application lets users log in with Spotify and view a genome of
+their top tracks.
+
+## Setup
+
+1. Create a Spotify developer application at [Spotify Developer Dashboard](https://developer.spotify.com/dashboard/).
+2. Add a redirect URI to that application. It must exactly match the
+   `SPOTIPY_REDIRECT_URI` environment variable you set for this app.
+3. Set the following environment variables when running the app:
+
+   - `SPOTIPY_CLIENT_ID` – your Spotify client ID
+   - `SPOTIPY_CLIENT_SECRET` – your Spotify client secret
+   - `SPOTIPY_REDIRECT_URI` – the URL Spotify should redirect back to
+     after authentication (e.g. `https://yourdomain.com/callback`)
+   - `FLASK_SECRET_KEY` – any random secret string
+
+If you encounter the error `INVALID_CLIENT: Invalid redirect URI`, the
+redirect URI from the login request did not match any of the URIs listed in your
+Spotify application. Ensure `SPOTIPY_REDIRECT_URI` matches exactly and that it is
+added in the Spotify dashboard.
+
+Run locally with:
+
+```bash
+pip install -r requirements.txt
+python app.py
+```
+
+The app will listen on port 5000 by default.

--- a/app.py
+++ b/app.py
@@ -8,10 +8,12 @@ app = Flask(__name__)
 app.secret_key = os.environ.get("FLASK_SECRET_KEY", "dev")
 
 # === Spotify OAuth Setup ===
+redirect_uri = os.environ.get("SPOTIPY_REDIRECT_URI", "http://localhost:5000/callback")
+print(f"\u2699\ufe0f Using redirect URI: {redirect_uri}")
 sp_oauth = SpotifyOAuth(
     client_id=os.environ.get("SPOTIPY_CLIENT_ID"),
     client_secret=os.environ.get("SPOTIPY_CLIENT_SECRET"),
-    redirect_uri=os.environ.get("SPOTIPY_REDIRECT_URI", "http://localhost:5000/callback"),
+    redirect_uri=redirect_uri,
     scope="user-read-private user-read-email user-top-read",
     show_dialog=True
 )


### PR DESCRIPTION
## Summary
- print the OAuth redirect URI at startup
- add README with setup instructions

## Testing
- `python3 -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6887a9f3b7fc8332b42d1a0e860fd774