### PR TITLE
Display top songs inline and add logout

### DIFF
--- a/app.py
+++ b/app.py
@@ -80,6 +80,7 @@ def profile():
 
 @app.route("/logout")
 def logout():
+    # Delete the session's token cache so old credentials aren't reused
     cache_path = session.pop("cache_path", None)
     if cache_path and os.path.exists(cache_path):
         try:
@@ -92,6 +93,7 @@ def logout():
 
 @app.route("/top_songs_data")
 def top_songs_data():
+    # Called via AJAX from the profile page to load songs without blocking
     sp = get_spotify()
     if sp is None:
         return jsonify({"error": "not authenticated"}), 401

--- a/app.py
+++ b/app.py
@@ -1,18 +1,32 @@
-from flask import Flask, request, redirect, session, url_for, render_template
+from flask import (
+    Flask,
+    request,
+    redirect,
+    session,
+    url_for,
+    render_template,
+    jsonify,
+)
 import spotipy
 from spotipy.oauth2 import SpotifyOAuth
 import os
+import time
+from uuid import uuid4
 
 app = Flask(__name__)
 app.secret_key = os.environ.get("FLASK_SECRET_KEY", "dev")
 
-# Spotify Auth setup
-sp_oauth = SpotifyOAuth(
-    client_id=os.environ.get("SPOTIPY_CLIENT_ID"),
-    client_secret=os.environ.get("SPOTIPY_CLIENT_SECRET"),
-    redirect_uri="https://www.dolphin-audio.com/callback",
-    scope="user-read-private user-read-email",
-)
+
+def make_sp_oauth(cache_path=None, state=None):
+    """Return a SpotifyOAuth instance with optional cache path."""
+    return SpotifyOAuth(
+        client_id=os.environ.get("SPOTIPY_CLIENT_ID"),
+        client_secret=os.environ.get("SPOTIPY_CLIENT_SECRET"),
+        redirect_uri="https://www.dolphin-audio.com/callback",
+        scope="user-read-private user-read-email user-top-read",
+        cache_path=cache_path,
+        state=state,
+    )
 
 @app.route("/")
 def index():
@@ -20,13 +34,18 @@ def index():
 
 @app.route("/login")
 def login():
-    auth_url = sp_oauth.get_authorize_url()
+    cache_path = f"/tmp/.cache-{uuid4().hex}"
+    session["cache_path"] = cache_path
+    oauth = make_sp_oauth(cache_path=cache_path)
+    auth_url = oauth.get_authorize_url()
     return redirect(auth_url)
 
 @app.route("/callback")
 def callback():
     code = request.args.get("code")
-    token_info = sp_oauth.get_access_token(code)
+    cache_path = session.get("cache_path")
+    oauth = make_sp_oauth(cache_path=cache_path)
+    token_info = oauth.get_access_token(code)
     session["token_info"] = token_info
     return redirect(url_for("profile"))
 
@@ -39,3 +58,42 @@ def profile():
     sp = spotipy.Spotify(auth=token_info["access_token"])
     user = sp.current_user()
     return render_template("profile.html", user=user)
+
+
+@app.route("/logout")
+def logout():
+    cache_path = session.pop("cache_path", None)
+    if cache_path and os.path.exists(cache_path):
+        try:
+            os.remove(cache_path)
+        except OSError:
+            pass
+    session.clear()
+    return redirect(url_for("index"))
+
+
+@app.route("/top_songs_data")
+def top_songs_data():
+    token_info = session.get("token_info", {})
+    if not token_info:
+        return jsonify({"error": "not authenticated"}), 401
+
+    sp = spotipy.Spotify(auth=token_info["access_token"])
+
+    tracks = []
+    for offset in (0, 50):
+        results = sp.current_user_top_tracks(
+            limit=50, offset=offset, time_range="long_term"
+        )
+        for item in results.get("items", []):
+            tracks.append(
+                {
+                    "name": item.get("name"),
+                    "artist": ", ".join(a["name"] for a in item.get("artists", [])),
+                    "url": item["external_urls"]["spotify"],
+                }
+            )
+        if offset == 0:
+            time.sleep(10)
+
+    return jsonify({"tracks": tracks})

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -10,6 +10,7 @@
     <p><a href="{{ url_for('logout') }}">Sign out</a></p>
 
     <h2>Your All-Time Top 100 Tracks</h2>
+    <!-- The track list is filled asynchronously after login -->
     <div id="tracks">Loading your top songs...</div>
 
     <script>

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -7,5 +7,29 @@
     <h1>🎧 Spotify Profile</h1>
     <p><strong>Display Name:</strong> {{ user.display_name }}</p>
     <p><strong>Email:</strong> {{ user.email }}</p>
+    <p><a href="{{ url_for('logout') }}">Sign out</a></p>
+
+    <h2>Your All-Time Top 100 Tracks</h2>
+    <div id="tracks">Loading your top songs...</div>
+
+    <script>
+    fetch("{{ url_for('top_songs_data') }}")
+      .then(resp => resp.json())
+      .then(data => {
+        const div = document.getElementById('tracks');
+        const ul = document.createElement('ul');
+        data.tracks.forEach(t => {
+          const li = document.createElement('li');
+          const a = document.createElement('a');
+          a.href = t.url;
+          a.target = '_blank';
+          a.textContent = t.name + ' - ' + t.artist;
+          li.appendChild(a);
+          ul.appendChild(li);
+        });
+        div.innerHTML = '';
+        div.appendChild(ul);
+      });
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- return `/top_songs_data` as JSON with delay
- load top 100 songs asynchronously on the profile page
- add logout route and link
- remove unused template
- ensure each session has its own OAuth cache file

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6887d36710088332997a768532c39a5c