### PR TITLE
Fix caching issue when switching Spotify accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ The login flow now forces Spotify to display the account selection dialog
 every time. This allows you to easily switch between Spotify accounts after
 logging out of the app.
 
+Token caching is also disabled so each login retrieves a fresh access token
+instead of reusing the one stored on disk. This prevents the previous user's
+profile from being displayed when switching accounts.
+
 If you encounter the error `INVALID_CLIENT: Invalid redirect URI`, the
 redirect URI from the login request did not match any of the URIs listed in your
 Spotify application. Ensure `SPOTIPY_REDIRECT_URI` matches exactly and that it is

--- a/app.py
+++ b/app.py
@@ -13,6 +13,7 @@ sp_oauth = SpotifyOAuth(
     client_secret=os.environ.get("SPOTIPY_CLIENT_SECRET"),
     redirect_uri=os.environ.get("SPOTIPY_REDIRECT_URI"),
     scope="user-read-private user-read-email user-top-read",
+    cache_path=None,
     show_dialog=True,
 )
 


### PR DESCRIPTION
## Summary
- disable Spotipy cache to prevent stale tokens from displaying old user information
- document the change

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_688a73d8e5fc833298b2be101fa1f89d