### PR TITLE
Fix missing secret key

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ their top tracks.
    - `SPOTIPY_CLIENT_SECRET` – your Spotify client secret
    - `SPOTIPY_REDIRECT_URI` – the URL Spotify should redirect back to
      after authentication (e.g. `https://yourdomain.com/callback`)
-   - `FLASK_SECRET_KEY` – any random secret string
+   - `FLASK_SECRET_KEY` – any random secret string. Optional, but providing one
+     ensures sessions persist across restarts. If omitted, the app generates a
+     temporary secret at runtime.
 
 The login flow now forces Spotify to display the account selection dialog
 every time. This allows you to easily switch between Spotify accounts after

--- a/app.py
+++ b/app.py
@@ -3,9 +3,13 @@ import spotipy
 from spotipy.oauth2 import SpotifyOAuth
 import os
 import time
+import secrets
 
 app = Flask(__name__)
-app.secret_key = os.environ.get("FLASK_SECRET_KEY")
+# Use a random secret if FLASK_SECRET_KEY is not provided. This prevents
+# runtime errors when the environment variable is missing, but sessions will be
+# reset on each restart unless a persistent secret is configured.
+app.secret_key = os.environ.get("FLASK_SECRET_KEY", secrets.token_hex(16))
 app.config.update(
     SESSION_COOKIE_SECURE=True,
     SESSION_COOKIE_HTTPONLY=True,


### PR DESCRIPTION
## Summary
- set a random secret key when FLASK_SECRET_KEY is not configured
- clarify README environment variable section

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_688a855db95c83328ff438456504839e