### PR TITLE
Improve Spotify OAuth session isolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ Token caching is also disabled so each login retrieves a fresh access token
 instead of reusing the one stored on disk. This prevents the previous user's
 profile from being displayed when switching accounts.
 
+Each login generates a new SpotifyOAuth instance with a unique state value so
+that credentials are never shared across sessions. All token refreshes create a
+fresh OAuth helper as well.
+
 No tokens or user data are stored globally. Everything is kept in the Flask
 session so each user's information is isolated from others.
 


### PR DESCRIPTION
## Summary
- generate a fresh `SpotifyOAuth` instance for each login/callback
- store a unique state value in the session and clear it after authentication
- refresh tokens using a newly created auth helper
- document the new isolation mechanism

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_688cdcd035a083328e23c2bf377466ea